### PR TITLE
Don't create CP_JAVA_HOME on Windows

### DIFF
--- a/windows/CellProfiler.iss
+++ b/windows/CellProfiler.iss
@@ -43,6 +43,3 @@ Source: "C:\hostedtoolcache\windows\jdk\14.0.1\x64\*"; DestDir: "{app}\java"; Fl
 [Icons]
 Name: "{commonprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
 Name: "{commondesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
-
-[Registry]
-Root: HKCU; Subkey: "Environment"; ValueType: string; ValueName: "CP_JAVA_HOME"; ValueData: "{app}\java"; Flags: createvalueifdoesntexist


### PR DESCRIPTION
If CellProfiler/python-javabridge#10 is merged, there is no longer a need for the Windows installer to create this environment variable when installing a frozen version of CellProfiler. This would resolve cellprofiler/cellprofiler#4320