### PR TITLE
Ubuntu 18 Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,36 +1,37 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
-ARG version=4.2.0
+ARG version=4.2.2
 
-# Install CellProfiler dependencies
-RUN apt-get update && apt-get install -y software-properties-common
-RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt -y update
+RUN apt update
 RUN apt -y upgrade
-RUN apt install -y python3.8-dev python3.8-distutils python3-pip openjdk-8-jdk-headless libmysqlclient-dev libnotify-dev libsdl2-dev wget
-# Uncomment the below if you want to make a version with the GUI
-# RUN apt install -y libwebkitgtk-3.0
+RUN apt install -y make gcc build-essential libgtk-3-dev wget git
+RUN apt install -y python3.8-dev python3.8-venv python3-pip openjdk-11-jdk-headless default-libmysqlclient-dev libnotify-dev libsdl2-dev libwebkit2gtk-4.0-dev
+RUN apt-get install -y \
+                freeglut3 \
+                freeglut3-dev \
+                libgl1-mesa-dev \
+                libglu1-mesa-dev \
+                libgstreamer-plugins-base1.0-dev \
+                libgtk-3-dev \
+                libgtk2.0-dev \
+                libjpeg-dev \
+                libnotify-dev \
+                libsdl2-dev \
+                libsm-dev \
+                libtiff-dev \
+                libwebkit2gtk-4.0-dev \
+                libwebkitgtk-dev \
+                libxtst-dev
 
-# Set up environment
-RUN export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-RUN export PATH=$PATH:/home/ubuntu/.local/bin
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3.8 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN pip install --upgrade pip
+RUN pip install wheel cython numpy
 
-# This is needed for a Python 3.8 quirk
-RUN apt remove -y python3-pip
-RUN wget https://bootstrap.pypa.io/get-pip.py
-RUN python3.8 get-pip.py
-RUN rm get-pip.py
+RUN pip install  -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04 wxPython==4.1.0
 
-#Install wx from a wheel
-RUN wget https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04/wxPython-4.1.0-cp38-cp38-linux_x86_64.whl
-RUN python3.8 -m pip install wxPython-4.1.0-cp38-cp38-linux_x86_64.whl
-RUN rm wxPython-4.1.0-cp38-cp38-linux_x86_64.whl
-
-# Install CellProfiler
-RUN python3.8 -m pip install numpy cython
-RUN python3.8 -m pip install cellprofiler==$version
-
-WORKDIR /usr/local/src
-ENTRYPOINT ["cellprofiler"]
+RUN pip install cellprofiler==$version
 
 CMD ["--run", "--run-headless", "--help"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,22 +6,6 @@ RUN apt update
 RUN apt -y upgrade
 RUN apt install -y make gcc build-essential libgtk-3-dev wget git
 RUN apt install -y python3.8-dev python3.8-venv python3-pip openjdk-11-jdk-headless default-libmysqlclient-dev libnotify-dev libsdl2-dev libwebkit2gtk-4.0-dev
-RUN apt-get install -y \
-                freeglut3 \
-                freeglut3-dev \
-                libgl1-mesa-dev \
-                libglu1-mesa-dev \
-                libgstreamer-plugins-base1.0-dev \
-                libgtk-3-dev \
-                libgtk2.0-dev \
-                libjpeg-dev \
-                libnotify-dev \
-                libsdl2-dev \
-                libsm-dev \
-                libtiff-dev \
-                libwebkit2gtk-4.0-dev \
-                libwebkitgtk-dev \
-                libxtst-dev
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 ENV VIRTUAL_ENV=/opt/venv

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,4 +18,7 @@ RUN pip install  -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubun
 
 RUN pip install cellprofiler==$version
 
+WORKDIR /usr/local/src
+ENTRYPOINT ["cellprofiler"]
+
 CMD ["--run", "--run-headless", "--help"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ARG version=4.2.2
+ARG version=4.2.3
 
 RUN apt update
 RUN apt -y upgrade

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -4,7 +4,7 @@ EXAMPLE_CDN = https://github.com/CellProfiler/examples/archive/master.zip
 # Public gold output files
 S3_GOLD = https://s3.amazonaws.com/cellprofiler-examples/example-human-gold-standard
 
-VERSION := 4.2.0
+VERSION := 4.2.1
 
 TAG := latest
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -4,7 +4,7 @@ EXAMPLE_CDN = https://github.com/CellProfiler/examples/archive/master.zip
 # Public gold output files
 S3_GOLD = https://s3.amazonaws.com/cellprofiler-examples/example-human-gold-standard
 
-VERSION := 4.2.2rc1
+VERSION := 4.2.3
 
 TAG := latest
 


### PR DESCRIPTION
Ubuntu 16 is no longer supported officially, and so we need a new one. I've put the tag here as 4.2.2 to make it clear that official images through 4.2.1 don't use this Docker, but obviously that tag isn't real (yet). 

I should say for the record that this Dockerfile seems to work fine with the current masters of `core` and `CellProfiler` if we actually install per below, but it seems to barf for `pip` installing CellProfiler in a way that I absolutely do not understand. Future-me probably wants to work on figuring this out, hence draft status, but it's possible that it's a package version issue (or gremlins, my preferred explanation is gremlins) and that it will just work ok with 4.2.2.

```
RUN git clone https://github.com/CellProfiler/core.git
RUN git clone https://github.com/CellProfiler/CellProfiler.git
WORKDIR core
RUN pip install -e .
WORKDIR ../CellProfiler
RUN pip install -e .
```

Shoutout to https://pythonspeed.com/articles/activate-virtualenv-dockerfile/ for getting me around some venv issues